### PR TITLE
fix(intersections): eliminate up to scale equivalent points

### DIFF
--- a/conics/geometry.py
+++ b/conics/geometry.py
@@ -1,6 +1,6 @@
 # conics - Python library for dealing with conics
 #
-# Copyright 2024 Sergiu Deitsch <sergiu.deitsch@gmail.com>
+# Copyright 2025 Sergiu Deitsch <sergiu.deitsch@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import numpy as np
+import numpy.typing as npt
 
 
 def hnormalized(p):
@@ -41,3 +42,40 @@ def rot2d(alpha):
     c = np.cos(alpha)
     s = np.sin(alpha)
     return np.array([[c, -s], [s, c]])
+
+
+def projectively_unique(p: npt.ArrayLike, atol: float = 1e-4) -> np.ndarray:
+    n = np.size(p, axis=-1)
+
+    # Pairwise cross-product between each intersection for filtering out
+    # multiplicative multiples
+    c = np.empty_like(p, shape=(n, n, 3))
+
+    for i in np.arange(n):
+        for j in np.arange(n):
+            c[i, j] = np.cross(np.take(p, i, axis=-1), np.take(p, j, axis=-1))
+
+    # Compute the norm of the cross-products which is zero for a pair of
+    # intersections that are equivalent up to scale
+    d = np.linalg.norm(c, axis=-1)
+    m = np.isclose(d, 0, atol=atol)
+    # The indices of the strictly upper-triangular part of the adjacency
+    # matrix
+    i, j = np.triu_indices(n, k=1)
+
+    duplicate = np.zeros(n, dtype=bool)
+
+    for k in np.arange(n):
+        if duplicate[k]:
+            continue
+
+        # Current row of the strictly upper-triangular matrix
+        r = m[k][j[k == i]]
+        # Determine duplicate intersections by evaluating the norm of the
+        # pairwise cross-product with respect to the current intersection
+        l = np.nonzero(r)
+        # Mark other intersections as duplicates to avoid repeated
+        # processing. Account for the offset of the diagonal element.
+        duplicate[k + l + 1] = True
+
+    return np.take(p, np.nonzero(~duplicate)[0], axis=-1)

--- a/tests/test_conics.py
+++ b/tests/test_conics.py
@@ -282,9 +282,9 @@ def test_single_circle_intersection():
     hinter = hnormalized(inter)
     hinter = np.unique(hinter, axis=1)
 
-    assert np.size(hinter, axis=-1) == 2
+    assert np.size(hinter, axis=-1) == 1
 
-    np.testing.assert_array_almost_equal(hinter, [[1, 1], [0, 0]])
+    np.testing.assert_array_almost_equal(hinter, [[1], [0]])
 
     c = c1 - c2
 
@@ -298,7 +298,7 @@ def test_ellipse_four_intersections():
 
     inter = hnormalized(e1.intersect(e2))
 
-    assert np.size(inter, axis=-1) == 12
+    assert np.size(inter, axis=-1) == 4
 
     np.testing.assert_array_almost_equal(e1(inter), 0)
     np.testing.assert_array_almost_equal(e2(inter), 0)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,6 +1,6 @@
 # conics - Python library for dealing with conics
 #
-# Copyright 2024 Sergiu Deitsch <sergiu.deitsch@gmail.com>
+# Copyright 2025 Sergiu Deitsch <sergiu.deitsch@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
 # limitations under the License.
 #
 
+from conics import Conic
 from conics.geometry import hnormalized
 from conics.geometry import homogeneous
 from conics.geometry import line_intersection
 from conics.geometry import line_through
+from conics.geometry import projectively_unique
 import numpy as np
 
 
@@ -32,3 +34,42 @@ def test_intersecting_lines():
 
     np.testing.assert_array_equal(hnormalized(p), 0.5)
     np.testing.assert_array_equal(homogeneous([0.5, 0.5]), np.atleast_2d(p / p[-1]).T)
+
+
+def test_projectively_unique_empty():
+    a = projectively_unique(np.empty((3, 0)))
+    assert a.shape == (3, 0)
+
+
+def test_projectively_unique_all():
+    a = projectively_unique([[0, 1], [0, 1], [0, 1]])
+    np.testing.assert_array_equal(a, [[0], [0], [0]])
+
+
+def test_projectively_unique():
+    a = projectively_unique([[1, 2, 3], [1, 2, 3], [1, 2, 3]])
+    np.testing.assert_array_equal(a, [[1], [1], [1]])
+
+
+def test_projectively_unique_four_intersections():
+    e1 = Conic.from_ellipse([0, 0], [2, 1], np.pi / 4)
+    e2 = Conic.from_ellipse([0, 0], [2, 1], np.pi * 3 / 4)
+
+    inter = hnormalized(e1.intersect(e2))
+    assert inter.shape == (2, 4)
+
+
+def test_projectively_unique_one_intersection():
+    c1 = Conic.from_circle([0, 0], 1)
+    c2 = c1.translate([2 * 1, 0])
+
+    inter = hnormalized(c1.intersect(c2))
+    assert inter.shape == (2, 1)
+
+
+def test_projectively_unique_two_intersections():
+    c1 = Conic.from_circle([0, 0], 1)
+    c2 = Conic.from_circle([0.5, 0], 1)
+
+    inter = hnormalized(c1.intersect(c2))
+    assert inter.shape == (2, 2)


### PR DESCRIPTION
Keep only the first intersection while discarding its multiplicative multiples.