### PR TITLE
Small numpy efficiency improvements

### DIFF
--- a/conics/__about__.py
+++ b/conics/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.1.0a2"
+__version__ = "0.1.0a3"

--- a/conics/_conic.py
+++ b/conics/_conic.py
@@ -356,11 +356,10 @@ class Conic:
 
         poly = np.array([alpha, beta, gamma, delta], dtype=complex)
         La = np.roots(poly)
-        PP = np.empty_like(poly, shape=(3, 0))
 
-        for la in La:
-            P = Conic.__intersect(la, A, B)
-            PP = np.column_stack((PP, P))
+        Ps = [Conic.__intersect(la, A, B) for la in La]
+        Ps.append(np.empty_like(poly, shape=(3, 0)))
+        PP = np.column_stack(Ps)
 
         # Use points that consists of real values only
         mask = ~np.any(~np.isclose(np.imag(PP), 0), axis=0)


### PR DESCRIPTION
In initially looking at this project to understand what was happening, I noticed some inefficiencies. This PR ideally cleans things up a little big, but also feel free to reject arbitrarily:

1. in `intersection`, `np.stack` is called inside the for-loop which causes successive reallocation of (admittedly fairly small) amounts of memory, this is switched to a single list allocation and then stack
2. in the recently added `projectively_unique` this was switched to just mark any index that's close to an earlier index as a duplicate. This is slightly different than what's originally there in two small ways:
    1. It computes all the cross products instead of just the set necessary. While ostensibly this is more computation, since its not dispatched inside a for loop, it can be done with a single python call, and in almost all cases is slightly more efficient
    2. in the current logic a point is marked as duplicate if it's close to a point that is not marked as duplicate. In this new version it's possible for 0 to be close to 1 and 1 to be close to 2, but 0 is not close enough to 2. In the current version 0 and 2 would would be returned. In the new version only 0 will be returned. This probably isn't an important difference, but it does exist.
3. this also adds types to some of the functions in `geometry`